### PR TITLE
Fix clazy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Run clang-tidy
         shell: bash
         run: |
-          find src -name '*.cpp' | xargs clang-tidy -p build --header-filter='^\.\./src/' 2>&1
+          find src -name '*.cpp' -print0 | xargs -0 -r clang-tidy -p build 2>&1
 
   codeql:
     name: CodeQL (${{ matrix.language }})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(KDDockWidgets
         GIT_REPOSITORY https://github.com/shyney7/KDDockWidgets.git
-        GIT_TAG        fix-multi-dockarea-quick-windows
+        GIT_TAG        v2.4.1
         GIT_SHALLOW    TRUE
         SYSTEM
     )
@@ -187,6 +187,7 @@ target_link_libraries(appZephyrSense
 # Suppress qDebug() output in Release builds (compile-time elimination)
 target_compile_definitions(appZephyrSense PRIVATE
     $<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG_OUTPUT>
+    QT_USE_QSTRINGBUILDER
 )
 
 if(WEBDEV_MODE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,11 @@ set(KDDockWidgets_TESTS OFF CACHE BOOL "" FORCE)
 set(KDDockWidgets_DOCS OFF CACHE BOOL "" FORCE)
 # Required: generates com/kdab/dockwidgets/qmldir + .qmltypes on disk for qmllint/language server
 set(KDDockWidgets_QML_MODULE ON CACHE BOOL "" FORCE)
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/KDDockWidgets-2.4.0/CMakeLists.txt")
-    add_subdirectory(libs/KDDockWidgets-2.4.0 SYSTEM)
+# KDDockWidgets — using shyney7/KDDockWidgets fork (not upstream KDAB) because
+# it includes the DOCKS_EXPORT fix on DockWidgetInstantiator, which is required
+# for type-safe PMF signal connects (see commit e5a67aa).
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/KDDockWidgets/CMakeLists.txt")
+    add_subdirectory(libs/KDDockWidgets SYSTEM)
 else()
     message(STATUS "KDDockWidgets not found locally, fetching from GitHub...")
     include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ else()
     message(STATUS "KDDockWidgets not found locally, fetching from GitHub...")
     include(FetchContent)
     FetchContent_Declare(KDDockWidgets
-        GIT_REPOSITORY https://github.com/KDAB/KDDockWidgets.git
-        GIT_TAG        v2.4.0
+        GIT_REPOSITORY https://github.com/shyney7/KDDockWidgets.git
+        GIT_TAG        fix-multi-dockarea-quick-windows
         GIT_SHALLOW    TRUE
         SYSTEM
     )

--- a/main.cpp
+++ b/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     // Set up I/O worker thread for non-blocking database and CSV operations
     QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir().mkpath(dataPath);
-    QString dbPath = dataPath + "/zephyrsense.db";
+    QString dbPath = dataPath + QStringLiteral("/zephyrsense.db");
 
     IOThread ioThread(dbPath);
     ioThread.start();

--- a/src/bridge/cesiumbridge.cpp
+++ b/src/bridge/cesiumbridge.cpp
@@ -116,7 +116,7 @@ void CesiumBridge::validateToken(const QString &token)
 
     QHttpHeaders headers;
     headers.append(QHttpHeaders::WellKnownHeader::Authorization,
-                   QStringLiteral("Bearer ") + token);
+                   QString(QStringLiteral("Bearer ") + token));
     request.setHeaders(std::move(headers));
     request.setTransferTimeout(15000);
 

--- a/src/bridge/cesiumbridge.cpp
+++ b/src/bridge/cesiumbridge.cpp
@@ -116,7 +116,7 @@ void CesiumBridge::validateToken(const QString &token)
 
     QHttpHeaders headers;
     headers.append(QHttpHeaders::WellKnownHeader::Authorization,
-                   QString(QStringLiteral("Bearer ") + token));
+                   QStringLiteral("Bearer ") + token);
     request.setHeaders(std::move(headers));
     request.setTransferTimeout(15000);
 

--- a/src/core/dockstatetracker.cpp
+++ b/src/core/dockstatetracker.cpp
@@ -1,6 +1,7 @@
 #include "dockstatetracker.h"
 
 #include <QQuickItem>
+#include <utility>
 #include <QQuickWindow>
 #include <kddockwidgets/core/DockWidget.h>
 #include <kddockwidgets/qtquick/views/DockWidget.h>
@@ -22,9 +23,10 @@ void DockStateTracker::trackDockWidget(QObject *dockWidget)
     if (!dockWidget)
         return;
 
-    // The QML KDDW.DockWidget type is DockWidgetInstantiator (internal KDDW class),
-    // not QtQuick::DockWidget directly. Access the actual dock via the "dockWidget"
-    // Q_PROPERTY to avoid depending on the internal header.
+    // The QML KDDW.DockWidget type is DockWidgetInstantiator, not QtQuick::DockWidget
+    // directly. Access the actual dock via the "dockWidget" Q_PROPERTY.
+    // String-based connect is required: DockWidgetInstantiator lacks DOCKS_EXPORT,
+    // so its symbols are not exported from the KDDW DLL on Windows.
     QVariant dwVar = dockWidget->property("dockWidget");
     auto *qtquickDock = qvariant_cast<KDDockWidgets::QtQuick::DockWidget *>(dwVar);
     if (!qtquickDock) {
@@ -38,12 +40,14 @@ void DockStateTracker::trackDockWidget(QObject *dockWidget)
 
     m_coreDocks.append(coreDock);
 
-    // Connect to the instantiator's signals (string-based connect since we don't
-    // include the DockWidgetInstantiator header)
+    // NOLINTBEGIN(clazy-old-style-connect)
+    // DockWidgetInstantiator is not DLL-exported (missing DOCKS_EXPORT),
+    // so PMF (pointer-to-member-function) connects cannot link on Windows.
     connect(dockWidget, SIGNAL(isFloatingChanged(bool)),
             this, SLOT(scheduleReevaluation()));
     connect(dockWidget, SIGNAL(isOpenChanged(bool)),
             this, SLOT(scheduleReevaluation()));
+    // NOLINTEND(clazy-old-style-connect)
 
     // Connect to the actual QQuickItem's windowChanged signal — fires when the
     // dock moves between the main window and a floating window
@@ -59,7 +63,7 @@ void DockStateTracker::scheduleReevaluation()
 void DockStateTracker::reevaluate()
 {
     bool hasAny = false;
-    for (const auto &ptr : m_coreDocks) {
+    for (const auto &ptr : std::as_const(m_coreDocks)) {
         if (ptr && ptr->isOpen() && !ptr->isInMainWindow()) {
             hasAny = true;
             break;

--- a/src/core/dockstatetracker.cpp
+++ b/src/core/dockstatetracker.cpp
@@ -2,7 +2,6 @@
 
 #include <QQuickItem>
 #include <utility>
-#include <QQuickWindow>
 #include <kddockwidgets/core/DockWidget.h>
 #include <DockWidgetInstantiator.h>
 #include <kddockwidgets/qtquick/views/DockWidget.h>

--- a/src/core/dockstatetracker.cpp
+++ b/src/core/dockstatetracker.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <QQuickWindow>
 #include <kddockwidgets/core/DockWidget.h>
+#include <DockWidgetInstantiator.h>
 #include <kddockwidgets/qtquick/views/DockWidget.h>
 
 DockStateTracker::DockStateTracker(QObject *parent)
@@ -23,14 +24,17 @@ void DockStateTracker::trackDockWidget(QObject *dockWidget)
     if (!dockWidget)
         return;
 
-    // The QML KDDW.DockWidget type is DockWidgetInstantiator, not QtQuick::DockWidget
-    // directly. Access the actual dock via the "dockWidget" Q_PROPERTY.
-    // String-based connect is required: DockWidgetInstantiator lacks DOCKS_EXPORT,
-    // so its symbols are not exported from the KDDW DLL on Windows.
-    QVariant dwVar = dockWidget->property("dockWidget");
-    auto *qtquickDock = qvariant_cast<KDDockWidgets::QtQuick::DockWidget *>(dwVar);
+    // The QML KDDW.DockWidget is a DockWidgetInstantiator, not QtQuick::DockWidget
+    // directly. Cast to the concrete type for type-safe signal connections.
+    auto *instantiator = qobject_cast<KDDockWidgets::DockWidgetInstantiator *>(dockWidget);
+    if (!instantiator) {
+        qWarning() << "[DockStateTracker] not a DockWidgetInstantiator:" << dockWidget;
+        return;
+    }
+
+    auto *qtquickDock = instantiator->dockWidget();
     if (!qtquickDock) {
-        qWarning() << "[DockStateTracker] dockWidget property cast failed for" << dockWidget;
+        qWarning() << "[DockStateTracker] dockWidget() returned null for" << dockWidget;
         return;
     }
 
@@ -40,14 +44,10 @@ void DockStateTracker::trackDockWidget(QObject *dockWidget)
 
     m_coreDocks.append(coreDock);
 
-    // NOLINTBEGIN(clazy-old-style-connect)
-    // DockWidgetInstantiator is not DLL-exported (missing DOCKS_EXPORT),
-    // so PMF (pointer-to-member-function) connects cannot link on Windows.
-    connect(dockWidget, SIGNAL(isFloatingChanged(bool)),
-            this, SLOT(scheduleReevaluation()));
-    connect(dockWidget, SIGNAL(isOpenChanged(bool)),
-            this, SLOT(scheduleReevaluation()));
-    // NOLINTEND(clazy-old-style-connect)
+    connect(instantiator, &KDDockWidgets::DockWidgetInstantiator::isFloatingChanged,
+            this, &DockStateTracker::scheduleReevaluation);
+    connect(instantiator, &KDDockWidgets::DockWidgetInstantiator::isOpenChanged,
+            this, &DockStateTracker::scheduleReevaluation);
 
     // Connect to the actual QQuickItem's windowChanged signal — fires when the
     // dock moves between the main window and a floating window

--- a/src/core/dockstatetracker.h
+++ b/src/core/dockstatetracker.h
@@ -35,4 +35,3 @@ private:
     QTimer m_deferTimer;
     bool m_hasDocksOutside = false;
 };
-

--- a/src/core/dockstatetracker.h
+++ b/src/core/dockstatetracker.h
@@ -25,10 +25,8 @@ public:
 signals:
     void changed();
 
-private slots:
-    void scheduleReevaluation();
-
 private:
+    void scheduleReevaluation();
     void reevaluate();
 
     QList<QPointer<KDDockWidgets::Core::DockWidget>> m_coreDocks;

--- a/src/core/sensorreading.h
+++ b/src/core/sensorreading.h
@@ -2,7 +2,7 @@
 
 #include <QDateTime>
 #include <QObject>
-#include <QtQmlIntegration>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <cstdint>
 
 // Raw binary struct matching embedded device protocol (42 bytes packed)

--- a/src/data/databasemanager.cpp
+++ b/src/data/databasemanager.cpp
@@ -14,7 +14,7 @@ DatabaseManager::DatabaseManager(QObject *parent)
     // Set up database path in app data location
     QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir().mkpath(dataPath);
-    m_databasePath = dataPath + "/zephyrsense.db";
+    m_databasePath = dataPath + QStringLiteral("/zephyrsense.db");
 }
 
 DatabaseManager::~DatabaseManager()
@@ -278,7 +278,7 @@ bool DatabaseManager::importDatabase(const QUrl &source)
     QSqlDatabase::removeDatabase(CONNECTION_NAME);
 
     // Backup current database
-    QString backupPath = m_databasePath + ".backup";
+    QString backupPath = m_databasePath + QStringLiteral(".backup");
     bool hadExisting = QFile::exists(m_databasePath);
     if (hadExisting) {
         QFile::remove(backupPath);  // Remove old backup if exists

--- a/src/models/sensorreadingmodel.cpp
+++ b/src/models/sensorreadingmodel.cpp
@@ -1,5 +1,6 @@
 #include "sensorreadingmodel.h"
 #include "coordinatevalidator.h"
+#include <utility>
 #include "databasemanager.h"
 #include "serialhandler.h"
 #include "thresholdmanager.h"
@@ -108,7 +109,7 @@ void SensorReadingModel::loadFromDatabase(const QDateTime &start, const QDateTim
     m_readings.clear();
 
     QVariantList results = dbManager->getReadingsInRange(start, end);
-    for (const QVariant &var : results) {
+    for (const QVariant &var : std::as_const(results)) {
         QVariantMap map = var.toMap();
         SensorReading reading;
         reading.partectorNumber = map[QStringLiteral("partectorNumber")].toInt();
@@ -135,7 +136,7 @@ void SensorReadingModel::loadFromDatabase(const QDateTime &start, const QDateTim
 
     // Sync m_nextId to avoid collisions between live reading IDs and database IDs
     qint64 maxId = 0;
-    for (const auto &entry : m_readings) {
+    for (const auto &entry : std::as_const(m_readings)) {
         maxId = qMax(maxId, entry.id);
     }
     if (maxId >= m_nextId) {

--- a/src/models/timeserieschartmodel.cpp
+++ b/src/models/timeserieschartmodel.cpp
@@ -1,5 +1,6 @@
 #include "timeserieschartmodel.h"
 #include "databasemanager.h"
+#include <utility>
 #include <QDebug>
 #include <QVariantMap>
 #include <limits>
@@ -69,7 +70,7 @@ void TimeSeriesChartModel::loadData(const QDateTime &start, const QDateTime &end
     qDebug() << "TimeSeriesChartModel: Loaded" << readings.count() << "readings from" << start << "to" << end;
 
     // Convert to DataPoint structs
-    for (const QVariant &v : readings) {
+    for (const QVariant &v : std::as_const(readings)) {
         QVariantMap map = v.toMap();
 
         DataPoint point;

--- a/src/serial/serialhandler.cpp
+++ b/src/serial/serialhandler.cpp
@@ -67,7 +67,7 @@ void SerialHandler::refreshPorts()
     for (const QSerialPortInfo &info : portInfos) {
         QString entry = info.portName();
         if (!info.description().isEmpty()) {
-            entry += " - " + info.description();
+            entry += QStringLiteral(" - ") + info.description();
         }
         m_ports.append(entry);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,7 +203,6 @@ qt_add_qml_module(tst_qml
     NO_PLUGIN
     SOURCES
         qml/setup/mocks.h
-        qml/setup/mocks.cpp
         ${CMAKE_SOURCE_DIR}/src/core/sensorreading.h
         ${CMAKE_SOURCE_DIR}/src/core/sensorreading.cpp
 )
@@ -224,7 +223,6 @@ target_link_libraries(tst_qml PRIVATE
 # Per-file warnings for tst_qml's actual sources only
 set(TST_QML_SOURCES
     qml/setup/tst_qml_setup.cpp
-    qml/setup/mocks.cpp
 )
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set_source_files_properties(${TST_QML_SOURCES} PROPERTIES

--- a/tests/qml/setup/mocks.cpp
+++ b/tests/qml/setup/mocks.cpp
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-// Ensures AUTOMOC processes mocks.h and generates mocks.moc
-#include "mocks.h"
-#include "mocks.moc"


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on type safety, code modernization, and minor dependency and path handling adjustments. The most significant changes include refactoring how dock widgets are tracked for better type safety, updating string handling to use `QStringLiteral`, and modernizing container iteration using `std::as_const`. Additionally, there are adjustments to dependency fetching and header includes for improved maintainability.

**Dock widget tracking and type safety improvements:**

* Refactored `DockStateTracker::trackDockWidget` to cast directly to `DockWidgetInstantiator` for type-safe signal connections, replacing property-based access and string-based signal connections with direct connections using function pointers. This enhances maintainability and reduces reliance on internal headers. [[1]](diffhunk://#diff-27fa04784a70fe46a5b45ea1d30876f0de6f30de1141374a0f4fba9a2583fa92L25-R37) [[2]](diffhunk://#diff-27fa04784a70fe46a5b45ea1d30876f0de6f30de1141374a0f4fba9a2583fa92L41-R50)
* Added direct include of `DockWidgetInstantiator.h` and `<utility>` in relevant files for improved type safety and code clarity. [[1]](diffhunk://#diff-27fa04784a70fe46a5b45ea1d30876f0de6f30de1141374a0f4fba9a2583fa92R4-R7) [[2]](diffhunk://#diff-05ad8b4077c63f1aa7eab60a63a20f03b56a9a13553deeca48f51cab5774b2f4R3) [[3]](diffhunk://#diff-6d9a1a4029426ed007ad6121536996e0fa5110fa83a276f39d4026cb959a1563R3)

**Modernization and code style improvements:**

* Replaced traditional for-loops with range-based loops using `std::as_const` for safe iteration over containers in multiple locations, including dock state tracking, sensor reading loading, and chart model data loading. [[1]](diffhunk://#diff-27fa04784a70fe46a5b45ea1d30876f0de6f30de1141374a0f4fba9a2583fa92L62-R66) [[2]](diffhunk://#diff-05ad8b4077c63f1aa7eab60a63a20f03b56a9a13553deeca48f51cab5774b2f4L111-R112) [[3]](diffhunk://#diff-05ad8b4077c63f1aa7eab60a63a20f03b56a9a13553deeca48f51cab5774b2f4L138-R139) [[4]](diffhunk://#diff-6d9a1a4029426ed007ad6121536996e0fa5110fa83a276f39d4026cb959a1563L72-R73)
* Moved `scheduleReevaluation()` from a private slot to a private method in `DockStateTracker`, reflecting its usage as an internal helper.

**String handling and path management:**

* Updated all string concatenations involving file paths and extensions to use `QStringLiteral` for efficiency and consistency, affecting database paths and serial port descriptions. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL105-R105) [[2]](diffhunk://#diff-7d9a1fe3f3228c68bd792456685b8e3fb430351c044a7cc8e54720b2deb37c0fL17-R17) [[3]](diffhunk://#diff-7d9a1fe3f3228c68bd792456685b8e3fb430351c044a7cc8e54720b2deb37c0fL281-R281) [[4]](diffhunk://#diff-abc965d89ab0ab790e9ab8f837ff61a71247783980f8f03464a218738ecf9199L70-R70)

**Dependency and header management:**

* Changed the KDDockWidgets dependency in `CMakeLists.txt` to fetch from a forked repository and a specific branch, likely to include needed fixes not present in the mainline.
* Updated the QtQmlIntegration include to use the specific header `<QtQmlIntegration/qqmlintegration.h>`.