### PR TITLE
Enable qmlsc static mode for full QML AOT compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,19 @@ qt_add_qml_module(appZephyrSense
     SOURCES ${ZEPHYR_SOURCES}
 )
 
+# Enable qmlsc static mode for full AOT compilation (no shadow checking).
+# Requires Qt Quick Compiler Extensions (commercial) — skip in CI
+# and gracefully degrade for open-source contributors.
+find_program(QMLSC_EXECUTABLE NAMES qmlsc qmlsc.exe)
+if(QMLSC_EXECUTABLE AND NOT DEFINED ENV{CI})
+    message(STATUS "qmlsc found: ${QMLSC_EXECUTABLE} — enabling static mode")
+    set_target_properties(appZephyrSense PROPERTIES
+        QT_QMLCACHEGEN_ARGUMENTS "--static"
+    )
+else()
+    message(STATUS "qmlsc not found or CI build — using default qmlcachegen")
+endif()
+
 # Strict compiler warnings — applied ONLY to our source files.
 # Qt-generated files (MOC, QML AOT, type registrations) are unaffected.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/src/bridge/cesiumbridge.h
+++ b/src/bridge/cesiumbridge.h
@@ -14,7 +14,7 @@ class QNetworkReply;
 class CesiumWorker;
 class ThresholdManager;
 
-class CesiumBridge : public QObject
+class CesiumBridge final : public QObject
 {
     Q_OBJECT
     QML_ELEMENT


### PR DESCRIPTION
Detect qmlsc (commercial Qt Quick Compiler Extensions) via find_program and enable --static mode for ahead-of-time compilation without shadow checking. Guarded by both qmlsc availability and NOT CI environment to gracefully degrade for open-source contributors and CI runners.

Also mark CesiumBridge as final, aligning it with all other singleton classes in the codebase.