### PR TITLE
refactor: centralize readings table DDL into shared header (fixes #12)

### DIFF
--- a/src/bridge/cesiumworker.cpp
+++ b/src/bridge/cesiumworker.cpp
@@ -1,5 +1,6 @@
 #include "cesiumworker.h"
 #include "coordinatevalidator.h"
+#include "readingsschema.h"
 
 #include <QDateTime>
 #include <QTimeZone>
@@ -64,29 +65,11 @@ void CesiumWorker::openDatabase(const QString &path)
 bool CesiumWorker::createTables()
 {
     QSqlQuery query(m_db);
-    if (!query.exec(QStringLiteral(R"(
-        CREATE TABLE IF NOT EXISTS readings (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp INTEGER NOT NULL,
-            partectorNumber INTEGER,
-            partectorDiam INTEGER,
-            partectorMass REAL,
-            grimmValue REAL,
-            temperature REAL,
-            humidity REAL,
-            pressure REAL,
-            altitude REAL,
-            latitude REAL,
-            longitude REAL,
-            co2 INTEGER
-        )
-    )"))) {
+    if (!query.exec(QString{kReadingsTableSql})) {
         qWarning() << "CesiumWorker: Failed to create readings table:" << query.lastError().text();
         return false;
     }
-    if (!query.exec(QStringLiteral(R"(
-        CREATE INDEX IF NOT EXISTS idx_timestamp ON readings(timestamp)
-    )"))) {
+    if (!query.exec(QString{kReadingsIndexSql})) {
         qWarning() << "CesiumWorker: Failed to create timestamp index:" << query.lastError().text();
     }
     return true;

--- a/src/data/databasemanager.cpp
+++ b/src/data/databasemanager.cpp
@@ -1,4 +1,5 @@
 #include "databasemanager.h"
+#include "readingsschema.h"
 
 #include <QSqlDatabase>
 #include <QSqlQuery>
@@ -68,38 +69,14 @@ void DatabaseManager::createTables()
     QSqlDatabase db = QSqlDatabase::database(CONNECTION_NAME);
     QSqlQuery query(db);
 
-    // Create readings table with all sensor fields
-    const QString createTableSql = QStringLiteral(R"(
-        CREATE TABLE IF NOT EXISTS readings (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp INTEGER NOT NULL,
-            partectorNumber INTEGER,
-            partectorDiam INTEGER,
-            partectorMass REAL,
-            grimmValue REAL,
-            temperature REAL,
-            humidity REAL,
-            pressure REAL,
-            altitude REAL,
-            latitude REAL,
-            longitude REAL,
-            co2 INTEGER
-        )
-    )");
-
-    if (!query.exec(createTableSql)) {
+    if (!query.exec(QString{kReadingsTableSql})) {
         QString error = QStringLiteral("Failed to create readings table: %1").arg(query.lastError().text());
         qWarning() << error;
         emit databaseError(error);
         return;
     }
 
-    // Create index on timestamp for efficient range queries
-    const QString createIndexSql = QStringLiteral(R"(
-        CREATE INDEX IF NOT EXISTS idx_timestamp ON readings(timestamp)
-    )");
-
-    if (!query.exec(createIndexSql)) {
+    if (!query.exec(QString{kReadingsIndexSql})) {
         QString error = QStringLiteral("Failed to create timestamp index: %1").arg(query.lastError().text());
         qWarning() << error;
         emit databaseError(error);

--- a/src/data/readingsschema.h
+++ b/src/data/readingsschema.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QLatin1StringView>
+
+/// Single source of truth for the readings-table DDL.
+/// Each caller executes these via its own QSqlQuery with its own error handling.
+
+inline constexpr QLatin1StringView kReadingsTableSql{R"(
+    CREATE TABLE IF NOT EXISTS readings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp INTEGER NOT NULL,
+        partectorNumber INTEGER,
+        partectorDiam INTEGER,
+        partectorMass REAL,
+        grimmValue REAL,
+        temperature REAL,
+        humidity REAL,
+        pressure REAL,
+        altitude REAL,
+        latitude REAL,
+        longitude REAL,
+        co2 INTEGER
+    )
+)"};
+
+inline constexpr QLatin1StringView kReadingsIndexSql{R"(
+    CREATE INDEX IF NOT EXISTS idx_timestamp ON readings(timestamp)
+)"};

--- a/src/threading/ioworker.cpp
+++ b/src/threading/ioworker.cpp
@@ -1,4 +1,5 @@
 #include "ioworker.h"
+#include "readingsschema.h"
 
 #include <QSqlQuery>
 #include <QSqlError>
@@ -77,36 +78,14 @@ void IOWorker::createTables()
 {
     QSqlQuery query(m_db);
 
-    const QString createTableSql = QStringLiteral(R"(
-        CREATE TABLE IF NOT EXISTS readings (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp INTEGER NOT NULL,
-            partectorNumber INTEGER,
-            partectorDiam INTEGER,
-            partectorMass REAL,
-            grimmValue REAL,
-            temperature REAL,
-            humidity REAL,
-            pressure REAL,
-            altitude REAL,
-            latitude REAL,
-            longitude REAL,
-            co2 INTEGER
-        )
-    )");
-
-    if (!query.exec(createTableSql)) {
+    if (!query.exec(QString{kReadingsTableSql})) {
         QString error = QStringLiteral("IOWorker: Failed to create readings table: %1").arg(query.lastError().text());
         qWarning() << error;
         emit databaseError(error);
         return;
     }
 
-    const QString createIndexSql = QStringLiteral(R"(
-        CREATE INDEX IF NOT EXISTS idx_timestamp ON readings(timestamp)
-    )");
-
-    if (!query.exec(createIndexSql)) {
+    if (!query.exec(QString{kReadingsIndexSql})) {
         QString error = QStringLiteral("IOWorker: Failed to create timestamp index: %1").arg(query.lastError().text());
         qWarning() << error;
         emit databaseError(error);

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -7,6 +7,7 @@
 #include <QSqlError>
 #include <QTemporaryDir>
 #include <QDebug>
+#include "readingsschema.h"
 #include "sensorreading.h"
 
 // ─── SensorReadingBuilder ────────────────────────────────────────────────────
@@ -143,29 +144,11 @@ public:
         }
 
         QSqlQuery query(db);
-        bool ok = query.exec(QStringLiteral(R"(
-            CREATE TABLE IF NOT EXISTS readings (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp INTEGER NOT NULL,
-                partectorNumber INTEGER,
-                partectorDiam INTEGER,
-                partectorMass REAL,
-                grimmValue REAL,
-                temperature REAL,
-                humidity REAL,
-                pressure REAL,
-                altitude REAL,
-                latitude REAL,
-                longitude REAL,
-                co2 INTEGER
-            )
-        )"));
+        bool ok = query.exec(QString{kReadingsTableSql});
         if (!ok)
             qWarning() << "TestDatabaseHelper: Table creation failed:" << query.lastError().text();
 
-        query.exec(QStringLiteral(R"(
-            CREATE INDEX IF NOT EXISTS idx_timestamp ON readings(timestamp)
-        )"));
+        query.exec(QString{kReadingsIndexSql});
 
         return ok;
     }


### PR DESCRIPTION
Extract duplicated CREATE TABLE and CREATE INDEX SQL from databasemanager.cpp, ioworker.cpp, cesiumworker.cpp, and testhelpers.h into src/data/readingsschema.h as constexpr QLatin1StringView constants. Each caller retains its own error handling. The two tst_databasemanager.cpp fixture copies (without IF NOT EXISTS) are left unchanged.
#12 